### PR TITLE
fix unnessesary overflow in auth layout

### DIFF
--- a/src/layouts/AuthLayout.tsx
+++ b/src/layouts/AuthLayout.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 function AuthLayout({ children }: Props) {
   return (
-    <div className="relative w-screen h-screen bg-muted">
+    <div className="relative w-screen h-screen bg-muted overflow-hidden">
       {children}
       <TailwindIndicator />
       <div


### PR DESCRIPTION
En la pantalla de login, cuando se clickea en ingresar sin haber rellenado los campos, las validaciones de campo requerido generan un overflow innesecesario.
![CRM login overflow](https://github.com/ConsigueVentas-Team/CRM_Frontend/assets/114877220/84522131-b894-4b70-b058-6f8ef73be6ec)
